### PR TITLE
Automatically add Qt wayland support to Qt executables on Linux

### DIFF
--- a/cmake/module/OB/Executable.cmake
+++ b/cmake/module/OB/Executable.cmake
@@ -226,9 +226,28 @@ function(ob_add_standard_executable target)
     endif()
 
     # Add wayland support to Qt executables on Linux, if available
-    if(_USE_QT AND CMAKE_SYSTEM_NAME STREQUAL Linux AND TARGET Qt6::WaylandClient)
-        # Shouldn't be an issue to add it as PRIVATE specifically even if it's
-        # already linked using a different scope.
+    if(_USE_QT AND CMAKE_SYSTEM_NAME STREQUAL Linux AND TARGET Qt6::WaylandClient AND TARGET Qt6::QWaylandIntegrationPlugin)
+        # We don't want to override the default platform plugin (usually xcb), but just
+        # include the wayland platform plugin with executeables if the plugin
+        # is available. This avoids the warning
+        #
+        # qt.qpa.plugin could not find the qt platform plugin "wayland" in ""
+        #
+        # from being printed by said executeables when they're run in a Desktop
+        # environment that uses Wayland, and allows users to start them under
+        # wayland if desired. If wayland ever becomes the default this won't be
+        # required anymore as the default platform plugin is always statically
+        # linked (see qt_internal_add_plugin())
+        #
+        # Default logic for app that use Qt GUI (otherwise mkspecs are used):
+        # https://github.com/qt/qtbase/blob/2636258b29fb09551f78a26512790dc66a4a3036/src/gui/CMakeLists.txt#L32
+        #
+        # It seems like the qt_import_plugins() call probably adds the plugin, while
+        # linking to the waylandclient target ensures that wayland related dependencies
+        # are deployed in shared builds
+        qt_import_plugins(${_TARGET_NAME}
+            INCLUDE Qt6::QWaylandIntegrationPlugin
+        )
         target_link_libraries(${_TARGET_NAME} PRIVATE Qt6::WaylandClient)
     endif()
 

--- a/cmake/module/OB/Executable.cmake
+++ b/cmake/module/OB/Executable.cmake
@@ -225,27 +225,11 @@ function(ob_add_standard_executable target)
         target_link_libraries(${_TARGET_NAME} ${_LINKS})
     endif()
 
-    # Add wayland support to static Qt executables on Linux
-    if(_USE_QT AND CMAKE_SYSTEM_NAME STREQUAL Linux)
-        # We don't want to override the default platform plugin (usually xcb), but just
-        # include the wayland platform plugin with static executeables if the plugin
-        # is available. This avoids the warning
-        #
-        # qt.qpa.plugin could not find the qt platform static plugin "wayland" in ""
-        #
-        # from being printed by said executeables when they're run in a Desktop
-        # environment that uses Wayland, and allows usesrs to start them under
-        # wayland if desired. If wayland ever becomes the default this won't be
-        # required anymore as the default platform plugin is always statically
-        # linked (see qt_internal_add_plugin())
-        #
-        # Default logic for app that use Qt GUI (otherwise mkspecs are used):
-        # https://github.com/qt/qtbase/blob/2636258b29fb09551f78a26512790dc66a4a3036/src/gui/CMakeLists.txt#L32
-        if(TARGET Qt6::QWaylandIntegrationPlugin)
-            qt_import_plugins(${_TARGET_NAME}
-                INCLUDE Qt6::QWaylandIntegrationPlugin
-            )
-        endif()
+    # Add wayland support to Qt executables on Linux, if available
+    if(_USE_QT AND CMAKE_SYSTEM_NAME STREQUAL Linux AND TARGET Qt6::WaylandClient)
+        # Shouldn't be an issue to add it as PRIVATE specifically even if it's
+        # already linked using a different scope.
+        target_link_libraries(${_TARGET_NAME} PRIVATE Qt6::WaylandClient)
     endif()
 
     # Add definitions


### PR DESCRIPTION
Was already partially implemented, but this does the rest for shared builds.

Sadly I can find no guidance on how this is supposed to be done, surprisingly enough, but this seems to get the job done for both static and shared builds.